### PR TITLE
[KP-1162] Allow both tfvars type and parsable JSON strings

### DIFF
--- a/config.json
+++ b/config.json
@@ -70,8 +70,8 @@
           "name": "variables",
           "viewName": "Vars",
           "type": "text",
-          "description": "Set values for input variables in the root module of the configuration, either key=value items separated by new line or as a JSON object.",
-          "placeholder": "region=ap-northwest-1\nsize=xlarge",
+          "description": "Input variables in the root module of the configuration, either key=value items separated by new line or text that parses as JSON.",
+          "placeholder": "region = \"ap-northwest-1\"\nsize = \"xlarge\"",
           "learnUrl": "https://learn.hashicorp.com/tutorials/terraform/variables"
         },
         {

--- a/helpers.js
+++ b/helpers.js
@@ -10,14 +10,6 @@ const { resolve: resolvePath } = require("path");
 
 const exec = promisify(childProcess.exec);
 
-function logToActivityLog(message) {
-  // TODO: Change console.error to console.info
-  // Right now (Kaholo v4.1.2.1) console.info
-  // does not print messages to Activity Log
-  // Jira ticket: https://kaholo.atlassian.net/browse/KAH-3636
-  console.error(message);
-}
-
 async function createVariablesString({
   varFile,
   variables,
@@ -45,7 +37,14 @@ async function createVariablesString({
     variablesText += "\n";
   }
   if (variables) {
-    variablesText += variables;
+    // parameter is "type": "text", but might be stringified JSON
+    try {
+      const varsObj = JSON.parse(variables);
+      const pairs = Object.keys(varsObj).map((key) => `${key} = "${varsObj[key]}"`).join("\n");
+      variablesText += pairs;
+    } catch {
+      variablesText += variables;
+    }
     variablesText += "\n";
   }
   if (variablesText.length) {
@@ -132,6 +131,5 @@ module.exports = {
   tryParseTerraformJsonOutput,
   exec,
   isJsonAllowed,
-  logToActivityLog,
   getCurrentUserId,
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1086,9 +1086,10 @@
       "license": "MIT"
     },
     "node_modules/json5": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.0"
       },
@@ -2292,7 +2293,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"


### PR DESCRIPTION
This is strange because if tfvars-style text is entered, we don't want to parse it as key-value pairs. It ends up text anyway. However we DO want to be able to code this with configuration and/or Inputs so it needs to accept a JSON object. Solution is to make it accept strings/text that passes JSON.parse(text).